### PR TITLE
Add debounce to loading dismiss effect.

### DIFF
--- a/src/app/book/book.effects.ts
+++ b/src/app/book/book.effects.ts
@@ -30,18 +30,18 @@ export class BookEffects {
   @Effect({dispatch: false})
   createLoadingOnSearchBooks$ = this.actions$.pipe(
     ofType(BookActionTypes.SearchBooks),
-    switchMap((action: SearchBooks) => {
-      this.loadingCtrl.create().then((loading) => {
-        this.loading = loading;
-        loading.present();
-      });
-      return of();
+    switchMap(async (action: SearchBooks) => {
+      const loading = await this.loadingCtrl.create();
+
+      this.loading = loading;
+      loading.present();
     })
   );
 
   @Effect({dispatch: false})
   dismissLoadingOnSearchBooks$ = this.actions$.pipe(
-    ofType(BookActionTypes.SearchBooksSuccess, BookActionTypes.SearchBooksError),
+    ofType(BookActionTypes.SearchBooksSuccess,
+      BookActionTypes.SearchBooksError),
     map(() => {
       if (this.loading) {
         this.loading.dismiss();

--- a/src/app/collection/effects/collection.effects.ts
+++ b/src/app/collection/effects/collection.effects.ts
@@ -85,12 +85,14 @@ export class CollectionEffects {
 
   @Effect({dispatch: false})
   createLoadingOnRequests$ = this.actions$.pipe(
-    ofType(CollectionActionTypes.AddBookToCollection, CollectionActionTypes.LoadCollection, CollectionActionTypes.RemoveExemplar),
-    map((action: AddBookToCollection) => {
-      this.loadingCtrl.create().then((loading) => {
-        this.loading = loading;
-        loading.present();
-      });
+    ofType(CollectionActionTypes.AddBookToCollection,
+      CollectionActionTypes.LoadCollection,
+      CollectionActionTypes.RemoveExemplar),
+    map(async (action: AddBookToCollection) => {
+      const loading = await this.loadingCtrl.create();
+
+      this.loading = loading;
+      loading.present();
     })
   );
 


### PR DESCRIPTION
This is necessary because currently it could be possible that an action that should dismiss the loading (e.g. LoginLocalStorageError) is dispatched before the loading Indicator is actually created.
The debounce should ensure that there was enough time for Ionic to create the loading.